### PR TITLE
Update ScrollView if there was a thumbnail image

### DIFF
--- a/QuickPhotoViewer/PhotoViewController.swift
+++ b/QuickPhotoViewer/PhotoViewController.swift
@@ -125,6 +125,10 @@ extension PhotoViewController {
             imageView.image = localImage
             self.updateScrollViewZoomScale()
         } else if let url = photo.url {
+            if let thumbnailImage = photo.thumbnailImage {
+                imageView.image = thumbnailImage
+                self.updateScrollViewZoomScale()
+            }
             downloadDelegate?.photoViewController(self, willStartDownloading: photo)
             let imageResource = ImageResource(downloadURL: url, cacheKey: url.cacheKey)
             imageView.kf.setImage(with: imageResource,


### PR DESCRIPTION
If I set thumbnail Image in QPhoto, the PhotoViewController won't show the thumbnail image properly. 
It needs to call updateScrollViewZoomScale() to make sure the thumbnail image appears in the center of the scroll view.